### PR TITLE
test(ci): add FCM dummy env vars for tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,8 @@ jobs:
           JWT_SECRET_KEY: "test-secret-key-for-ci-pipeline-do-not-use-in-production"
           ACCESS_DURATION: "3600000"
           REFRESH_DURATION: "604800000"
+          FCM_PROJECT_ID: "test-project-id"
+          FCM_JSON: "{}"
         run: ./gradlew test --no-daemon
 
       - name: Upload Test Results
@@ -140,6 +142,8 @@ jobs:
           JWT_SECRET_KEY: "test-secret-key-for-ci-pipeline-do-not-use-in-production"
           ACCESS_DURATION: "3600000"
           REFRESH_DURATION: "604800000"
+          FCM_PROJECT_ID: "test-project-id"
+          FCM_JSON: "{}"
         run: ./gradlew integrationTest --no-daemon
 
       - name: Upload Integration Test Results


### PR DESCRIPTION
## Summary
- add FCM_PROJECT_ID dummy env to Unit Test job
- add FCM_JSON dummy env to Unit Test job
- add same dummy envs to Integration Test job

## Why
- prevent CI failures when new FCM env vars are required in runtime config
- keep CD aligned with server-side env file strategy (no extra CD injection)

Closes #113