### PR TITLE
v2 Docker CI/CD 워크플로우 반영

### DIFF
--- a/.github/workflows/cd-docker.yml
+++ b/.github/workflows/cd-docker.yml
@@ -1,0 +1,158 @@
+name: Backend CD Docker (Dev/Prod)
+
+on:
+  workflow_run:
+    workflows: ["Backend CI/CD Docker"]
+    types: [completed]
+    branches: [dev, main]
+
+permissions:
+  id-token: write
+  contents: read
+  actions: read
+
+env:
+  AWS_REGION: ap-northeast-2
+  ECR_REPOSITORY: ${{ vars.V2_ECR_REPOSITORY || 'billage-be' }}
+  IMAGE_TAG: ${{ github.event.workflow_run.head_sha }}
+  DEV_ASG_NAME: ${{ vars.V2_DEV_ASG_NAME || 'billage-dev-v2-be-asg' }}
+  PROD_ASG_NAME: ${{ vars.V2_PROD_ASG_NAME || 'billage-prod-v2-be-asg' }}
+  DEV_MIN_HEALTHY: ${{ vars.V2_DEV_MIN_HEALTHY || '0' }}
+  PROD_MIN_HEALTHY: ${{ vars.V2_PROD_MIN_HEALTHY || '50' }}
+  DEV_INSTANCE_WARMUP: ${{ vars.V2_DEV_INSTANCE_WARMUP || '30' }}
+  PROD_INSTANCE_WARMUP: ${{ vars.V2_PROD_INSTANCE_WARMUP || '120' }}
+
+concurrency:
+  group: cd-docker-${{ github.event.workflow_run.head_branch }}
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Deploy Backend (v2)
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'push' &&
+      (
+        github.event.workflow_run.head_branch == 'dev' ||
+        (
+          github.event.workflow_run.head_branch == 'main' &&
+          vars.ENABLE_V2_PROD_CD == 'true'
+        )
+      )
+
+    steps:
+      - name: Determine Environment
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event.workflow_run.head_branch }}" = "dev" ]; then
+            echo "ASG_NAME=${DEV_ASG_NAME}" >> "$GITHUB_ENV"
+            echo "MIN_HEALTHY=${DEV_MIN_HEALTHY}" >> "$GITHUB_ENV"
+            echo "INSTANCE_WARMUP=${DEV_INSTANCE_WARMUP}" >> "$GITHUB_ENV"
+            echo "ENVIRONMENT=DEV" >> $GITHUB_ENV
+          elif [ "${{ github.event.workflow_run.head_branch }}" = "main" ]; then
+            echo "ASG_NAME=${PROD_ASG_NAME}" >> "$GITHUB_ENV"
+            echo "MIN_HEALTHY=${PROD_MIN_HEALTHY}" >> "$GITHUB_ENV"
+            echo "INSTANCE_WARMUP=${PROD_INSTANCE_WARMUP}" >> "$GITHUB_ENV"
+            echo "ENVIRONMENT=PROD" >> $GITHUB_ENV
+          else
+            echo "Unsupported branch"
+            exit 1
+          fi
+
+      - name: Configure AWS Credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          role-session-name: github-actions-backend-cd
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Confirm Image Exists in ECR
+        run: |
+          set -euo pipefail
+          aws ecr describe-images \
+            --repository-name $ECR_REPOSITORY \
+            --image-ids imageTag=${IMAGE_TAG}
+
+      - name: Validate v2 ASG Configuration
+        run: |
+          set -euo pipefail
+
+          if [[ ! "$MIN_HEALTHY" =~ ^[0-9]+$ ]] || [ "$MIN_HEALTHY" -lt 0 ] || [ "$MIN_HEALTHY" -gt 100 ]; then
+            echo "MIN_HEALTHY must be 0~100. current=$MIN_HEALTHY"
+            exit 1
+          fi
+
+          if [[ ! "$INSTANCE_WARMUP" =~ ^[0-9]+$ ]]; then
+            echo "INSTANCE_WARMUP must be a positive integer. current=$INSTANCE_WARMUP"
+            exit 1
+          fi
+
+          ASG_COUNT=$(aws autoscaling describe-auto-scaling-groups \
+            --auto-scaling-group-names "${ASG_NAME}" \
+            --query 'length(AutoScalingGroups)' \
+            --output text)
+
+          if [ "${ASG_COUNT}" -eq 0 ]; then
+            echo "ASG not found: ${ASG_NAME}"
+            exit 1
+          fi
+
+      - name: Trigger ASG Instance Refresh
+        run: |
+          set -euo pipefail
+
+          REFRESH_ID=$(aws autoscaling start-instance-refresh \
+            --auto-scaling-group-name "${ASG_NAME}" \
+            --strategy Rolling \
+            --preferences "{\"MinHealthyPercentage\": ${MIN_HEALTHY}, \"InstanceWarmup\": ${INSTANCE_WARMUP}}" \
+            --query 'InstanceRefreshId' \
+            --output text)
+
+          if [ -z "$REFRESH_ID" ] || [ "$REFRESH_ID" = "None" ]; then
+            echo "Failed to start instance refresh"
+            exit 1
+          fi
+
+          echo "REFRESH_ID=$REFRESH_ID" >> "$GITHUB_ENV"
+
+      - name: Wait for Instance Refresh
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 120); do
+            STATUS=$(aws autoscaling describe-instance-refreshes \
+              --auto-scaling-group-name "${ASG_NAME}" \
+              --instance-refresh-ids "${REFRESH_ID}" \
+              --query 'InstanceRefreshes[0].Status' \
+              --output text)
+
+            echo "[$i] ${ENVIRONMENT} refresh status: ${STATUS}"
+
+            if [ "${STATUS}" = "Successful" ]; then
+              exit 0
+            fi
+
+            if [ "${STATUS}" = "Failed" ] || [ "${STATUS}" = "Cancelled" ]; then
+              exit 1
+            fi
+
+            sleep 15
+          done
+
+          echo "Timeout waiting for instance refresh"
+          exit 1
+
+      - name: Notify Success
+        if: success()
+        run: |
+          curl -H "Content-Type: application/json" -X POST \
+            -d "{\"content\":\"**[${ENVIRONMENT}] Backend Docker 배포 성공**\\nASG: \`${ASG_NAME}\`\\nCommit: \`${IMAGE_TAG}\`\\nRefresh: \`${REFRESH_ID}\`\"}" \
+            "${{ secrets.DISCORD_WEBHOOK }}"
+
+      - name: Notify Failure
+        if: failure()
+        run: |
+          curl -H "Content-Type: application/json" -X POST \
+            -d "{\"content\":\"**[${ENVIRONMENT}] Backend Docker 배포 실패**\\nASG: \`${ASG_NAME}\`\\nCommit: \`${IMAGE_TAG}\`\"}" \
+            "${{ secrets.DISCORD_WEBHOOK }}"

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -157,13 +157,31 @@ jobs:
           retention-days: 7
 
   # ===========================================
-  # main 브랜치 전용: Docker Build & ECR Push
+  # 배포 브랜치 전용: Docker Build & ECR Push
+  # - dev: Unit Test 통과 후 Push
+  # - main: Unit + Integration Test 통과 후 Push
   # ===========================================
   docker-build-push:
     name: Docker Build & ECR Push
     runs-on: ubuntu-latest
     needs: [build-and-test, integration-test]
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: >-
+      ${{
+        always() &&
+        github.event_name == 'push' &&
+        needs.build-and-test.result == 'success' &&
+        (
+          github.ref == 'refs/heads/dev' ||
+          (
+            github.ref == 'refs/heads/main' &&
+            needs.integration-test.result == 'success'
+          )
+        ) &&
+        (
+          needs.integration-test.result == 'success' ||
+          needs.integration-test.result == 'skipped'
+        )
+      }}
 
     steps:
       - name: Checkout


### PR DESCRIPTION
## 근본 목적
v2 인프라의 배포 신뢰도를 높이기 위해 Docker 이미지는 CI에서 단일 생성/Push하고, CD는 해당 SHA 이미지 검증 후 ASG Instance Refresh만 수행하도록 역할을 분리한다.

## 비목적
테스트를 위한 포크 전용 브랜치 트리거/조건을 협업 레포에 그대로 반영하는 것이 목적이 아니다.

## 변경 사항
- `.github/workflows/cd-docker.yml` 추가
- CD를 `workflow_run` 기반으로 실행하고, `dev/main`만 대상으로 배포
- CD에서 소스 checkout/artifact 다운로드/이미지 재빌드 제거
- CD는 ECR의 `${IMAGE_TAG}`(CI SHA) 존재 확인 후 ASG refresh 수행
- `.github/workflows/ci-docker.yml`의 `docker-build-push`를 dev/main push 경로에 맞게 보정
- `integration-test`가 `skipped`인 dev 경로에서도 `docker-build-push`가 실행되도록 `always()` 조건 적용

## 검증
- YAML 파싱: `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci-docker.yml'); YAML.load_file('.github/workflows/cd-docker.yml')"`
- 포크 리허설 실행 결과
  - CI (`22469587025`) 성공 + Docker Build & ECR Push 성공
  - CD (`22469724212`) 성공 + ASG refresh 완료

Closes #122
