### PR TITLE
ci/cd: dev 이미지 태그를 latest로 통일

### DIFF
--- a/.github/workflows/cd-docker.yml
+++ b/.github/workflows/cd-docker.yml
@@ -73,7 +73,7 @@ jobs:
             ASG_NAME="${DEV_ASG_NAME}"
             MIN_HEALTHY="${DEV_MIN_HEALTHY}"
             INSTANCE_WARMUP="${DEV_INSTANCE_WARMUP}"
-            RUNTIME_TAG="dev-latest"
+            RUNTIME_TAG="latest"
             DEPLOY_LABEL="DEV"
           elif [ "$DEPLOY_ENV" = "main" ] || [ "$DEPLOY_ENV" = "prod" ]; then
             ASG_NAME="${PROD_ASG_NAME}"

--- a/.github/workflows/ci-docker.yml
+++ b/.github/workflows/ci-docker.yml
@@ -158,7 +158,7 @@ jobs:
 
   # ===========================================
   # 배포 브랜치 전용: Docker Build & ECR Push
-  # - dev: Unit Test 통과 후 Push (billage-be:dev-latest)
+  # - dev: Unit Test 통과 후 Push (billage-be:latest)
   # - main: Unit + Integration Test 통과 후 Push (billage-be:prod-latest)
   # ===========================================
   docker-build-push:
@@ -220,7 +220,7 @@ jobs:
           if [ "${{ github.ref_name }}" = "main" ]; then
             tags="${repo}:${{ github.sha }},${repo}:prod-latest"
           else
-            tags="${repo}:${{ github.sha }},${repo}:dev-latest"
+            tags="${repo}:${{ github.sha }},${repo}:latest"
           fi
 
           echo "tags=${tags}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## 근본 목적
개발(dev) 배포 경로에서 사용하는 런타임 이미지 태그를 일관되게 맞춰, CI push 결과와 CD pull 대상의 불일치를 제거합니다.

## 비목적
prod 배포 동작이나 애플리케이션 코드 로직 변경은 포함하지 않습니다.

## 변경 내용
- ci-docker: dev 브랜치 이미지 태그를 `dev-latest` -> `latest`로 변경
- cd-docker: dev 배포 시 런타임 태그를 `dev-latest` -> `latest`로 변경
- prod(main) 경로의 `prod-latest`는 유지
